### PR TITLE
[0.0.3] Update the package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "spiget",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spiget",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Javascript/Typescript client for the spiget.org API",
   "main": "index.js",
   "scripts": {

--- a/src/generator/index.ts
+++ b/src/generator/index.ts
@@ -3,11 +3,10 @@ import { Definition } from "./swagger/definition";
 import { TypeGenerator } from "./type";
 import { Path } from "./swagger/path";
 import { join } from "path";
-import { GENERATED_TYPES_DIR, buildWithNewLines, TYPES_DIR, SKIPPED_PATHS } from "./util";
-import { createWriteStream, WriteStream, writeFileSync, existsSync, mkdirSync } from "fs";
+import { GENERATED_TYPES_DIR, TYPES_DIR, SKIPPED_PATHS } from "./util";
+import { createWriteStream, WriteStream, existsSync, mkdirSync } from "fs";
 import { FunctionGenerator } from "./function";
 import { Method } from "./swagger/method";
-import { allImplImports } from "./implementation";
 import { ImportsGenerator } from "./imports";
 
 export function start() {

--- a/src/generator/util.ts
+++ b/src/generator/util.ts
@@ -1,5 +1,3 @@
-import { Schema } from "./swagger/schema";
-
 /**
  * The source directory to generate the types inside it
  */


### PR DESCRIPTION
This PR just changes the `0.0.3` commit to include the `package-lock.json` in it. 😁 

Since `package.json` and `package-lock.json`, both should be synced to ensure the same environment in all contributors.

The PR will result in generating a new commit which will override the old one. So, you may have to change the tag from the old commit to the new one. I tried to include that tag change in the PR but it wasn't possible [(Reference)](https://stackoverflow.com/a/12279290). 😓 