### PR TITLE
Add "dist" to the NPM package

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,10 @@
   "version": "0.0.3",
   "description": "Javascript/Typescript client for the spiget.org API",
   "main": "index.js",
+  "files": [
+    "dist/**/*",
+    "example.js"
+  ],
   "scripts": {
     "test": "mocha",
     "compile": "tsc",


### PR DESCRIPTION
# Info
This PR provides the opportunity to the dist folder and an example to be packaged when publishing to the [npm](http://npmjs.com/).

I tried to package `v0.0.3` with this PR and the package size was **`10.6 KB`** and the unpacked size was **`72.3 KB`**. 😄 

# Getting Started
- Clone [My Fork](https://github.com/iHDeveloper/spiget-typescript) from branch `add-to-dist-package`
- Compile the library by executing `npm run build`
- Package the library locally using `npm pack`
- You will notice a file called `spiget-{version}.tgz` To unpack it execute `tar -xvzf spiget-{version}.tgz`
- You can now browse the final package in a folder called `package` before publishing it :D
